### PR TITLE
refactor: moved sort change logic from parent to t-grid

### DIFF
--- a/src/app/chess/components/chess-grid/chess-grid.component.html
+++ b/src/app/chess/components/chess-grid/chess-grid.component.html
@@ -3,7 +3,7 @@
     [pageSize]="20"
     (sortChange)="onSortChange($event)"
     (paginationChange)="onPaginationChange($event)">
-    @for(column of columns(); track $index) {
+    @for(column of columns(); track columnTrackBy($index, column)) {
         <t-column [sortable]="column.sortable"
         [name]="column.name"
         [property]="column.property"

--- a/src/app/chess/components/chess-grid/chess-grid.component.ts
+++ b/src/app/chess/components/chess-grid/chess-grid.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, OnInit, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
 import { TColumnComponent } from '../../../shared/components/t-column/t-column.component';
 import { TGridComponent } from '../../../shared/components/t-grid/t-grid.component';
 import { ChessGridService } from '../../services/chess-grid.service';
@@ -63,13 +63,11 @@ export class ChessGridComponent {
 
   public readonly columns = this.#columns.asReadonly();
 
+  public columnTrackBy<T>(index: number, column: ColumnDef<ChessGridData>): string {
+    return (column.property as string) ?? index.toString();
+  }
+
   public onSortChange(sortChange: SortChange): void {
-    this.#columns.update((columns) =>
-      columns.map((column) => ({
-        ...column,
-        sortDirection: column.name == sortChange.columnName ? sortChange.direction : Direction.NONE,
-      }))
-    );
     console.log('[UIPATH] Parent sort change:', sortChange);
   }
 

--- a/src/app/shared/components/t-grid/t-grid.component.html
+++ b/src/app/shared/components/t-grid/t-grid.component.html
@@ -1,19 +1,18 @@
 @let rows = viewRows();
+@let viewColumns = columns();
 @let hasNoData = progress() != 100;
 
-@if(columns().length) {
-    @let viewColumns = columns();
-
+@if(viewColumns.length) {
     <div class="table-wrapper">
         <table>
             <thead>
                 <tr>
                     @for (column of viewColumns; track columnTrackBy($index, column)) {
-                        @let sortDirection = column.sortDirection();
-                        @let sortable = column.sortable();
+                        @let sortDirection = column.sortDirection;
+                        @let sortable = column.sortable;
 
                         <th [ngClass]="{'cursor-pointer': sortable, 'disabled': hasNoData}" (click)="!hasNoData ? onSortChange(column) : null">
-                            <span>{{column.name()}}</span>
+                            <span>{{column.name}}</span>
                             @if(sortable) {
                                 <span class="table-wrapper__sort-icon">
                                     @if (sortDirection === Direction.ASC) {▲}
@@ -34,7 +33,7 @@
                     @for (row of rows; track rowTrackBy($index, row)) {
                         <tr>
                             @for (column of viewColumns; track columnTrackBy($index, column)) {
-                                @let cellText = row[column.property()];
+                                @let cellText = row[column.property];
                                 <td>
                                     <span>{{cellText}}</span>
                                 </td>

--- a/src/app/shared/components/t-grid/t-grid.component.spec.ts
+++ b/src/app/shared/components/t-grid/t-grid.component.spec.ts
@@ -158,12 +158,12 @@ describe('TGridComponent', () => {
   describe('onSortChange', () => {
     it('should set current to 0 and emit sort change', () => {
       const spy = spyOn(component.sortChange, 'emit');
-      const column = {
-        name: signal('Rating'),
-        property: signal('rating'),
-        sortable: signal(true),
-        sortDirection: signal(Direction.NONE),
-      } as any as TColumnComponent<ChessGridData>;
+      const column: ColumnDef<ChessGridData> = {
+        name: 'Rating',
+        property: 'rating',
+        sortable: true,
+        sortDirection: Direction.NONE,
+      };
       spyOn(TGridUtils, 'getNextSortDirection').and.returnValue(Direction.NONE);
       component.onSortChange(column);
 
@@ -176,12 +176,12 @@ describe('TGridComponent', () => {
 
     it('should not emit sort change if column is not sortable', () => {
       const spy = spyOn(component.sortChange, 'emit');
-      const column = {
-        name: signal('Rating'),
-        property: signal('rating'),
-        sortable: signal(false),
-        sortDirection: signal(Direction.NONE),
-      } as any as TColumnComponent<ChessGridData>;
+      const column: ColumnDef<ChessGridData> = {
+        name: 'Rating',
+        property: 'rating',
+        sortable: false,
+        sortDirection: Direction.NONE,
+      };
       component.onSortChange(column);
 
       expect(spy).not.toHaveBeenCalled();
@@ -189,12 +189,12 @@ describe('TGridComponent', () => {
 
     it('should not emit sort change if table is not sortable', () => {
       const spy = spyOn(component.sortChange, 'emit');
-      const column = {
-        name: signal('Rating'),
-        property: signal('rating'),
-        sortable: signal(true),
-        sortDirection: signal(Direction.NONE),
-      } as any as TColumnComponent<ChessGridData>;
+      const column: ColumnDef<ChessGridData> = {
+        name: 'Rating',
+        property: 'rating',
+        sortable: true,
+        sortDirection: Direction.NONE,
+      };
       componentRef.setInput('sortable', false);
       fixture.detectChanges();
       component.onSortChange(column);
@@ -205,7 +205,7 @@ describe('TGridComponent', () => {
 
   describe('viewRows', () => {
     beforeEach(() => {
-      component.columns = signal([
+      component.columnComponents = signal([
         {
           name: signal('Rating'),
           property: signal('rating'),
@@ -221,12 +221,12 @@ describe('TGridComponent', () => {
       const paginateSpy = spyOn(TGridUtils, 'getPaginatedRows')
         .withArgs(expected, 10, 0)
         .and.returnValue(expected);
-      const column = {
-        name: signal('Rating'),
-        property: signal('rating'),
-        sortable: signal(true),
-        sortDirection: signal(Direction.NONE),
-      } as any as TColumnComponent<ChessGridData>;
+      const column: ColumnDef<ChessGridData> = {
+        name: 'Rating',
+        property: 'rating',
+        sortable: true,
+        sortDirection: Direction.NONE,
+      };
       spyOn(TGridUtils, 'mapTColumnComponentsToColumnDef').and.returnValue([
         {
           name: 'Rating',


### PR DESCRIPTION
What's changed
===================
- Moved logic regarding the update of the sort column direction + reset other columns to sort direction none to `TGrid`, because was wrong to have two source of truths. 
- This way `TGrid` can be reused anywhere without needing any external logic to work. `TGrid` handles all internal state.
- This will also fix the double computation of `viewRows`: one was from on `onSortChange` signals marked as dirty, the other was because the parent updated it's columns, which would be marked as dirty, then `viewRows` computes again.
- TGrid now uses `ColumnDef<T>` instead of `TColumnComponent<T>` for columns.